### PR TITLE
Add --no-container option, support no directories

### DIFF
--- a/mdbench.py
+++ b/mdbench.py
@@ -19,6 +19,7 @@ Usage: mdbench [options] <PATH>
     -d, --dirs  <N>  : number of generated directories to generate
     -s, --size  <N>  : size of generated files in B/K/M/G
     -n, --no-clean   : do not delete created files and directories
+    --no-container   : do not create the 'mdbench.<name>.<pid>' directory
     -h, --help       : help message
 
   and PATH points to the directory where tests should run. Current directory
@@ -128,10 +129,11 @@ def main():
 	file_count = FILE_COUNT
 	file_size = FILE_SIZE
 	cleanup = True
+	createContainer = True
 
 	try:
 		options, remainder = getopt.gnu_getopt(sys.argv[1:], 'f:d:s:nh', \
-					 ['files=','dirs=','size=','no-clean','help'])
+					 ['files=','dirs=','size=','no-clean','no-container','help'])
 	except getopt.GetoptError as err:
 		print str(err)
 		usage()
@@ -145,6 +147,8 @@ def main():
 			file_size = get_size(arg)
 		elif opt in ('-n', '--no-clean'):
 			cleanup = False
+		elif opt in ('--no-container'):
+			createContainer = False
 		elif opt in ('-h', '--help'):
 			usage()
 
@@ -153,9 +157,11 @@ def main():
 
 	path = remainder[0]
 
-	root = '%s/mdbench.%s.%d' % (path, socket.gethostname(), os.getpid())
+	root = '%s/mdbench.%s.%d' % (path, socket.gethostname(), os.getpid()) if createContainer else path
 
-	os.mkdir(root)
+	if createContainer:
+		os.mkdir(root)
+
 	elapsed, result = bench_run( make_dirs, root, dir_count )
 	in_sec = total_seconds(elapsed)
 	print '%.2f dir creates per second' % (dir_count/in_sec)
@@ -177,7 +183,8 @@ def main():
 		in_sec = total_seconds(elapsed)
 		print '%.2f dir removes per second' % (dir_count/in_sec)
 
-		os.rmdir(root)
+		if createContainer:
+			os.rmdir(root)
 
 if __name__ == '__main__':
 	main()

--- a/mdbench.py
+++ b/mdbench.py
@@ -25,6 +25,10 @@ Usage: mdbench [options] <PATH>
   and PATH points to the directory where tests should run. Current directory
   is used if not specified.
 
+If number of generated directories is 0 then files are created within
+the container directory ("mdbench.<name>.<pid>") or in PATH if
+--no-container is specified.
+
 The file size can be specified in human friendly format, e.g.: 1K, 256M. 4G.
 '''
 
@@ -65,14 +69,20 @@ def make_dirs(root, count):
 		os.mkdir( gen_dir(root, i) )
 
 def make_files(root, dir_count, file_count, size = 0):
-    for j in range(file_count):
-	    for i in range(dir_count):
-			mkfile(gen_file( gen_dir(root, i), j ), size, 1024)
+	for j in range(file_count):
+		if dir_count > 0:
+			for i in range(dir_count):
+				mkfile(gen_file( gen_dir(root, i), j ), size, 1024)
+		else:
+			mkfile(gen_file(root, j), size, 1024)
 
 def del_files(root, dir_count, file_count):
-	for i in range(dir_count):
-		for j in range(file_count):
-			os.remove(gen_file( gen_dir(root, i), j ))
+	for j in range(file_count):
+		if dir_count > 0:
+			for i in range(dir_count):
+				os.remove(gen_file( gen_dir(root, i), j ))
+		else:
+			os.remove(gen_file(root, j))
 
 def del_dirs(root, count):
 	for i in range(count):
@@ -83,9 +93,13 @@ def stat_dirs(root, count):
 		os.stat( gen_dir(root, i) )
 
 def stat_files(root, dir_count, file_count):
-	for i in range(dir_count):
-		for j in range(file_count):
-			os.stat(gen_file( gen_dir(root, i), j ))
+	for j in range(file_count):
+		if dir_count > 0:
+			for i in range(dir_count):
+				os.stat(gen_file( gen_dir(root, i), j ))
+		else:
+			os.stat(gen_file(root, j))
+
 
 def mkfile(fname, size = 0, chunk = 65536, sync = False) :
 	n_chunks = size // chunk
@@ -168,16 +182,17 @@ def main():
 
 	elapsed, result = bench_run( make_files, root, dir_count, file_count , file_size)
 	in_sec = total_seconds(elapsed)
-	print '%.2f file creates per second' % ((dir_count*file_count)/in_sec)
+	count = (dir_count if dir_count > 0 else 1) * file_count
+	print '%.2f file creates per second' % (count/in_sec)
 
 	elapsed, result = bench_run( stat_files, root, dir_count, file_count )
 	in_sec = total_seconds(elapsed)
-	print '%.2f file stats per second' % ((dir_count*file_count)/in_sec)
+	print '%.2f file stats per second' % (count/in_sec)
 
 	if cleanup:
 		elapsed, result = bench_run( del_files, root, dir_count, file_count )
 		in_sec = total_seconds(elapsed)
-		print '%.2f file removes per second' % ((dir_count*file_count)/in_sec)
+		print '%.2f file removes per second' % (count/in_sec)
 
 		elapsed, result = bench_run( del_dirs, root, dir_count )
 		in_sec = total_seconds(elapsed)


### PR DESCRIPTION
Motivation:

If mdbench is run on a single node, the container directory is unnecessary.  Avoid unnecessary directory creation

Modification:

Add --no-container option to avoid creating the mdbench.x.y directory.  Add support for -d0, which does not create any directories, but still creates files (if requested).

Default behaviour remains unchanged

Result:

Possible to avoid creating an unnecessary directory.